### PR TITLE
Adds X-Flash header logic

### DIFF
--- a/assets/js/App.vue
+++ b/assets/js/App.vue
@@ -3,6 +3,9 @@
     <div class="row">
       <nav-bar class="col s12"></nav-bar>
     </div>
+
+    <div v-if="flash.info">{{ flash.info }}</div>
+
     <breadcrumbs />
     <router-view></router-view>
   </div>
@@ -17,6 +20,7 @@ import AuctionsList from './auctions/List.vue'
 import AuctionsNew from './auctions/New.vue'
 import AuctionsEdit from './auctions/Edit.vue'
 import AuctionsShow from './auctions/Show.vue'
+import globals from './globals'
 
 const routes = [
   { path: '/', component: Landing, name: 'home' },
@@ -42,7 +46,12 @@ export default {
   components: {
     'nav-bar': Navbar
   },
-  router
+  router,
+  computed: {
+    flash: function() {
+      return globals.flash
+    }
+  }
 }
 </script>
 

--- a/assets/js/Landing.vue
+++ b/assets/js/Landing.vue
@@ -6,7 +6,6 @@
         <div class="col s12">
             <div class="row">
                 <router-link to="auctions" class="col s3 btn" id="look-for-auctions">Auctions</router-link>
-                <router-link to="my-auctions" class="col s3 offset-s2 btn">My auctions</router-link>
             </div>
         </div>
     </div>

--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -20,6 +20,7 @@ import Vue from "vue"
 import VueResource from 'vue-resource'
 import VueRouter from 'vue-router'
 import VueBreadcrumbs from 'vue-breadcrumbs'
+import globals from './globals'
 
 Vue.use(VueResource);
 Vue.use(VueRouter);
@@ -33,6 +34,18 @@ Vue.use(VueBreadcrumbs, {
     '<span v-if="key != $breadcrumbs.length - 1">&nbsp;/&nbsp;</span>' +
     '</router-link> ' +
     '</nav>'
+});
+
+Vue.http.interceptors.push(function() {
+    return function(response) {
+        var {'x-flash': flash} =  response.headers.map
+        if (!flash) return
+
+        flash = JSON.parse(flash)
+        Object.keys(flash).forEach(function(key){
+            window.M.toast({html: flash[key]})
+        })
+    }
 });
 
 import App from './App.vue'

--- a/assets/js/auctions/Edit.vue
+++ b/assets/js/auctions/Edit.vue
@@ -31,6 +31,7 @@ export default {
             return Vue.http.put(`/auctions/${this.auction.id}`, { auction: data })
             .then((response)  => {
                 this.errors = { title: [], description: []}
+                this.$router.push(`/auctions/${this.auction.id}`)
             }, (error) => {
                 this.errors = error.body.errors
             })

--- a/assets/js/globals.js
+++ b/assets/js/globals.js
@@ -1,5 +1,11 @@
 import Vue from 'vue'
 
-const globals = Vue.observable({ userId: null })
+const globals = Vue.observable({
+  userId: null,
+  flash: {
+    info: null,
+    error: null
+  }
+})
 
 export default globals

--- a/lib/auction_app_web.ex
+++ b/lib/auction_app_web.ex
@@ -23,6 +23,7 @@ defmodule AuctionAppWeb do
 
       import Plug.Conn
       import AuctionAppWeb.Gettext
+      import AuctionAppWeb.Helpers.FlashHeader
       alias AuctionAppWeb.Router.Helpers, as: Routes
     end
   end
@@ -35,6 +36,7 @@ defmodule AuctionAppWeb do
 
       # Import convenience functions from controllers
       import Phoenix.Controller, only: [get_flash: 1, get_flash: 2, view_module: 1]
+      import Jason
 
       # Use all HTML functionality (forms, tags, etc)
       use Phoenix.HTML

--- a/lib/auction_app_web/controllers/auctions_controller.ex
+++ b/lib/auction_app_web/controllers/auctions_controller.ex
@@ -29,6 +29,7 @@ defmodule AuctionAppWeb.AuctionsController do
       {:ok, auction} ->
         conn
         |> put_status(201)
+        |> put_flash_header(:info, "Auction created successfully")
         |> json(%{ auction: auction })
       {:error, %Ecto.Changeset{} = changeset} ->
         response_with_errors(conn, changeset)
@@ -41,6 +42,7 @@ defmodule AuctionAppWeb.AuctionsController do
       true ->
         Auction.delete(auction)
         conn
+        |> put_flash_header(:info, "Auction #{auction.title} deleted")
         |> send_resp(200, "")
       false ->
         send_resp(conn, 401, "")
@@ -54,7 +56,9 @@ defmodule AuctionAppWeb.AuctionsController do
         Auction.update(auction, auction_data)
         |> case do
           {:ok, auction} ->
-            send_resp(conn, 200, "")
+            conn
+            |> put_flash_header(:info, "Auction updated successfully")
+            |> send_resp(200, "")
           {:error, %Ecto.Changeset{} = changeset} ->
             response_with_errors(conn, changeset)
         end

--- a/lib/auction_app_web/helpers/flash_header.ex
+++ b/lib/auction_app_web/helpers/flash_header.ex
@@ -1,0 +1,23 @@
+defmodule AuctionAppWeb.Helpers.FlashHeader do
+  import Plug.Conn
+
+  def put_flash_header(conn, key, value) do
+    new_flash_header = conn
+    |> get_flash_header()
+    |> Map.put(key, value)
+
+    {:ok, json_value} = new_flash_header |> Jason.encode
+    conn
+    |> put_private(:flash_header, new_flash_header)
+    |> put_resp_header("x-flash", json_value)
+  end
+
+  def get_flash_header(conn, key) do
+    get_flash_header(conn)
+    |> Map.get(key, nil)
+  end
+
+  def get_flash_header(conn) do
+   Map.get(conn.private, :flash_header) || %{}
+  end
+end

--- a/priv/repo/migrations/20190227202934_change_auction_description_type.exs
+++ b/priv/repo/migrations/20190227202934_change_auction_description_type.exs
@@ -1,0 +1,9 @@
+defmodule AuctionApp.Repo.Migrations.ChangeAuctionDescriptionType do
+  use Ecto.Migration
+
+  def change do
+    alter table(:auctions) do
+      modify :description, :text
+    end
+  end
+end

--- a/test/auction_app_web/helpers/flash_header_test.exs
+++ b/test/auction_app_web/helpers/flash_header_test.exs
@@ -1,0 +1,30 @@
+defmodule AuctionAppWeb.Plugs.AuthenticationTest do
+  use ExUnit.Case, async: true
+  use Plug.Test
+
+  import AuctionAppWeb.Helpers.FlashHeader
+
+  test "flash_header is initially empty" do
+    flash_header = conn(:get, "/")
+    |> get_flash_header()
+
+    assert flash_header == %{}
+  end
+
+  test "put_flash_header adds X-Flash http header" do
+    header = conn(:get, "/")
+    |> put_flash_header(:info, "foo")
+    |> get_resp_header("x-flash")
+
+    assert header == ["{\"info\":\"foo\"}"]
+  end
+
+  test "put_flash_header adds X-Flash http header with info an error" do
+    header = conn(:get, "/")
+    |> put_flash_header(:info, "foo")
+    |> put_flash_header(:error, "baz")
+    |> get_resp_header("x-flash")
+
+    assert header == ["{\"error\":\"baz\",\"info\":\"foo\"}"]
+  end
+end


### PR DESCRIPTION
Adds the function put_flash_header into the backend to allow it
to set the header X-Flash easily from controllers.

Then on the frontend an interceptor take a look on the responses
headers. If the header "X-Flash" exists a toast is created with it.

closes #21 